### PR TITLE
Add clear-effects-on-load config option

### DIFF
--- a/src/main/java/net/jeqo/gizmo/listeners/ScreenHandlers.java
+++ b/src/main/java/net/jeqo/gizmo/listeners/ScreenHandlers.java
@@ -80,6 +80,13 @@ public class ScreenHandlers implements Listener {
 
     // Disable all potion effects
     private void disableEffects(Player p) {
+
+        if (Objects.equals(plugin.getConfig().getString("clear-effects-on-load"), "false")){
+            p.removePotionEffect(PotionEffectType.BLINDNESS);
+            return;
+        }
+
+
         for (PotionEffectType effect : PotionEffectType.values()) {
             if (p.hasPotionEffect(effect)) {
                 p.removePotionEffect(effect);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,6 +31,8 @@ commands-on-advance:
 player-invulnerable-during-load: true
 blindness-during-prompt: true # Give players blindness when they have the pack prompt.
 
+clear-effects-on-load: true
+
 kick-on-decline: false # Kick the player if they don't accept the pack.
 
 hide-join-messages: false # If true, player join messages will be hidden.


### PR DESCRIPTION
# Description

Added a boolean option to toggle the cleanse of all effects upon loading the resourcepack. This change keeps the cleaning of the Blindness effect. Also edited the disableEffects method, to properly accomodate the config changes.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Changes were tested locally and on a hosted server, and proven to work as intended 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if any
- [x] My changes generate no new warnings
- [x] I have performed tests that prove my fix is effective or that my feature works, if necessary
- [ ] New and existing unit tests pass locally with my changes